### PR TITLE
Fix output file handling

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -116,8 +116,7 @@ else:
     print("\nOutput:")
     print(decoded)
 
-
-    if args.output_file:
-        with open(args.output_file, "w") as f:
-            f.write(final_output)
-        print(f"\nOutput written to {args.output_file}")
+if args.output_file:
+    with open(args.output_file, "w") as f:
+        f.write(final_output)
+    print(f"\nOutput written to {args.output_file}")


### PR DESCRIPTION
## Summary
- ensure generate.py writes output file regardless of `--readable`

## Testing
- `pytest -q`
- `python -m py_compile generate.py`


------
https://chatgpt.com/codex/tasks/task_b_6889aa4880ec8328982960aca2e9d426