### PR TITLE
Fix syntax in prepare_dataset

### DIFF
--- a/scripts/prepare_dataset.py
+++ b/scripts/prepare_dataset.py
@@ -66,7 +66,7 @@ def prepare_dataset(input_path, tokenizer_path, output_path, debug=False):
 if __name__ == "__main__":
     prepare_dataset(
         input_path=config["corpus_path"],
-        tokenizer_path=config["tokenizer_path"]
+        tokenizer_path=config["tokenizer_path"],
         output_path=config["bin_path"],
         debug=config["debug"] 
     )


### PR DESCRIPTION
## Summary
- add missing comma in `prepare_dataset()` call

## Testing
- `python -m py_compile scripts/prepare_dataset.py`

------
https://chatgpt.com/codex/tasks/task_b_6889aa49ff508328b18b96734d0710b8