### PR TITLE
Improve dataset ingest script

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ uv pip install pyarrow
 
 ## Preparing Data
 
-1. **Ingest code** (optional): The `ingestion/ingest.py` script downloads Python code from [the‑stack](https://huggingface.co/datasets/bigcode/the-stack) using the `datasets` library. It caches files in `~/.cache/huggingface`.
-**Warning:** The full dataset contains 206 parquet files roughly 300MB each, so the complete download is quite large.
+1. **Ingest code** (optional): The `ingestion/ingest.py` script downloads the dataset configured in `config/config.py`. If `dataset_path` is set it will load from that directory instead of fetching from Hugging Face. The downloaded split is saved to `parquet_path` so the extraction script can process the parquet files.
+**Warning:** Large datasets may require significant disk space and download time.
 
 2. **Extract text**: Use `scripts/extract_parquets_to_text.py` to convert downloaded parquet files to a plain text corpus.
 3. **Sample subset** (optional): `scripts/sample_corpus_subset.py` allows you to sample a subset of the corpus if the extracted text is very large.
@@ -68,7 +68,7 @@ Both scripts load `gpt_model.pt` by default and print top‑k predictions at eac
 - `train.py`, `trainv2.py` – Training scripts (character‑level and BPE)
 - `generate.py`, `generatev2.py` – Text generation utilities
 - `scripts/` – Helper scripts for tokenizer training and dataset preparation
-- `ingestion/` – Example ingestion script for the-stack dataset
+- `ingestion/` – Example ingestion script for downloading Hugging Face datasets
 
 Enjoy experimenting with this tiny GPT model!
 

--- a/config/config.py
+++ b/config/config.py
@@ -2,9 +2,9 @@ config = {
     "debug": False, # Set False when you're not inspecting stuff. Will output a LOT
 
     #ingestion parameters    
-    "dataset":"storytracer/LoC-PD-Books",
-    "dataset_path": None,
-    "parquet_path":"~/.cache/huggingface/hub/datasets--storytracer--LoC-PD-Books/snapshots/5f1f4ee054362bcddbb56640c6beb67a92a0bf41/data",
+    "dataset":"storytracer/LoC-PD-Books",  # Hugging Face dataset name
+    "dataset_path": None,  # Set to a local directory to load the dataset from disk
+    "parquet_path":"~/.cache/huggingface/hub/datasets--storytracer--LoC-PD-Books/snapshots/5f1f4ee054362bcddbb56640c6beb67a92a0bf41/data",  # Directory where downloaded parquet files will be stored
     "ingestion_output_path":"data/stack_books_extracted.txt",  # Path to save all extracted Python from The Stack
     "language_filter": None,  # Set to None (the value, not a string) to extract from all langs
     "content_column": "text",  # Change if your parquet format differs

--- a/ingestion/ingest.py
+++ b/ingestion/ingest.py
@@ -4,13 +4,22 @@
 from datasets import load_dataset
 import sys
 import os
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'config')))
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "config")))
 from config import config
 
-if config['dataset_dir'] is not None:
-ds = load_dataset(config["dataset"], data_dir=config["dataset_path"], split="train")
+# Determine if a local dataset directory is specified
+dataset_kwargs = {}
+if config.get("dataset_path"):
+    dataset_kwargs["data_dir"] = config["dataset_path"]
 
-ds = load_dataset(config["dataset"], split="train")
+# Load the dataset split
+ds = load_dataset(config["dataset"], split="train", **dataset_kwargs)
+
+# Save the downloaded dataset so the extraction step can access the parquet files
+parquet_dir = os.path.expanduser(config["parquet_path"])
+os.makedirs(parquet_dir, exist_ok=True)
+ds.to_parquet(parquet_dir)
 
 print(ds)
 print(ds[0])

--- a/scripts/prepare_dataset.py
+++ b/scripts/prepare_dataset.py
@@ -66,7 +66,7 @@ def prepare_dataset(input_path, tokenizer_path, output_path, debug=False):
 if __name__ == "__main__":
     prepare_dataset(
         input_path=config["corpus_path"],
-        tokenizer_path=config["tokenizer_path"]
+        tokenizer_path=config["tokenizer_path"],
         output_path=config["bin_path"],
-        debug=config["debug"] 
+        debug=config["debug"],
     )


### PR DESCRIPTION
## Summary
- load dataset using `dataset_path` if provided
- save ingested dataset as parquet files
- document dataset download behaviour in README
- clarify `dataset_path` description in config
- fix syntax error in prepare_dataset.py

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6889aa4b5958832897b509bcc3dadbd7