### PR TITLE
Fix sampling script to avoid OOM

### DIFF
--- a/scripts/sample_corpus_subset.py
+++ b/scripts/sample_corpus_subset.py
@@ -1,27 +1,40 @@
 import random
 import sys
 import os
+
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'config')))
 from config import config
 
 def sample_corpus(input_path, output_path, num_lines=config["sample_lines"], shuffle=True):
-    print(f"Reading from: {input_path}")
-    with open(input_path, 'r', encoding='utf-8') as f:
-        lines = f.readlines()
+    """Sample ``num_lines`` from ``input_path`` without loading the full file."""
 
-    print(f"Total lines in corpus: {len(lines):,}")
+    num_lines = int(str(num_lines).replace("_", ""))
+    print(f"Reading from: {input_path}")
+
+    reservoir = []
+    total_lines = 0
+
+    with open(input_path, 'r', encoding='utf-8') as f:
+        for line in f:
+            total_lines += 1
+            if len(reservoir) < num_lines:
+                reservoir.append(line)
+            else:
+                j = random.randint(0, total_lines - 1)
+                if j < num_lines:
+                    reservoir[j] = line
+
+    print(f"Total lines in corpus: {total_lines:,}")
 
     if shuffle:
-        print(f"Shuffling and sampling {num_lines} lines...")
-        random.shuffle(lines)
-
-    sampled = lines[:num_lines]
+        print(f"Shuffling {len(reservoir):,} sampled lines...")
+        random.shuffle(reservoir)
 
     print(f"Saving to: {output_path}")
     with open(output_path, 'w', encoding='utf-8') as f:
-        f.writelines(sampled)
+        f.writelines(reservoir)
 
-    print(f"Done. Saved {len(sampled):,} lines.")
+    print(f"Done. Saved {len(reservoir):,} lines.")
 
 if __name__ == "__main__":
     sample_corpus(


### PR DESCRIPTION
## Summary
- avoid loading the entire corpus in `sample_corpus_subset.py`
- use reservoir sampling so the script can handle huge corpora

## Testing
- `python -m py_compile scripts/sample_corpus_subset.py`

------
https://chatgpt.com/codex/tasks/task_b_6889d6e0f9e08328a6a9cd40900c5be0